### PR TITLE
Add issues badge with link to waffle.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![Build Status](https://travis-ci.org/ontohub/ontohub-frontend.svg?branch=master)](https://travis-ci.org/ontohub/ontohub-frontend)
 [![Coverage Status](https://coveralls.io/repos/github/ontohub/ontohub-frontend/badge.svg?branch=master)](https://coveralls.io/github/ontohub/ontohub-frontend?branch=master)
 [![Code Climate](https://codeclimate.com/github/ontohub/ontohub-frontend/badges/gpa.svg)](https://codeclimate.com/github/ontohub/ontohub-frontend)
-[![Dependency Updates](https://david-dm.org/ontohub/ontohub-frontend/dev-status.svg)](https://david-dm.org/ontohub/ontohub-frontend?type=dev)
+[![Dependency Updates](https://img.shields.io/david/dev/ontohub/ontohub-frontend.svg?maxAge=2592000)](https://david-dm.org/ontohub/ontohub-frontend?type=dev)
+[![GitHub issues](https://img.shields.io/github/issues/ontohub/ontohub-frontend.svg?maxAge=2592000)](https://waffle.io/ontohub/ontohub-backend?source=ontohub%2Fontohub-frontend)
 
 # ontohub-frontend
 The Ontohub web UI for the end user.


### PR DESCRIPTION
<!-- If this Pull Request includes changes to the User Interface, please add Screenshots of the changes to the description. -->

Also changes the david badge to use the shields.io badge, since the david badge often breaks or does not load at all.