### PR TITLE
15 split development and production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
   "author": "",
   "license": "AGPL-3.0",
   "dependencies": {
-    "bower": "^1.7.9"
-  },
-  "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "broccoli-clean-css": "^1.1.0",
     "codeclimate-test-reporter": "^0.3.3",
@@ -56,5 +53,7 @@
     "liquid-fire": "0.25.0",
     "loader.js": "^4.0.1",
     "postcss-scss": "^0.3.0"
+  },
+  "devDependencies": {
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "author": "",
   "license": "AGPL-3.0",
+  "dependencies": {
+    "bower": "^1.7.9"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "broccoli-clean-css": "^1.1.0",


### PR DESCRIPTION
Shall fix #15. This does not technically split production and development dependencies, but adds a `dependencies` key. As far as the deployment is concerned (because of `ember build --environment production`), all current packages are needed in the build step.
