### PR TITLE
Update dependency badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/ontohub/ontohub-frontend.svg?branch=master)](https://travis-ci.org/ontohub/ontohub-frontend)
 [![Coverage Status](https://coveralls.io/repos/github/ontohub/ontohub-frontend/badge.svg?branch=master)](https://coveralls.io/github/ontohub/ontohub-frontend?branch=master)
 [![Code Climate](https://codeclimate.com/github/ontohub/ontohub-frontend/badges/gpa.svg)](https://codeclimate.com/github/ontohub/ontohub-frontend)
-[![Dependency Updates](https://img.shields.io/david/dev/ontohub/ontohub-frontend.svg?maxAge=2592000)](https://david-dm.org/ontohub/ontohub-frontend?type=dev)
+[![Dependency Updates](https://img.shields.io/david/ontohub/ontohub-frontend.svg?maxAge=2592000)](https://david-dm.org/ontohub/ontohub-frontend)
 [![GitHub issues](https://img.shields.io/github/issues/ontohub/ontohub-frontend.svg?maxAge=2592000)](https://waffle.io/ontohub/ontohub-backend?source=ontohub%2Fontohub-frontend)
 
 # ontohub-frontend


### PR DESCRIPTION
Since we no longer have dev dependencies, we should change the badge as well.

