### PR TITLE
Enable linting on tests only

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-disable no-undef */
 /* global require, module */
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
@@ -8,6 +8,7 @@ module.exports = function(defaults) {
     'ember-cli-foundation-6-sass': {
       'foundationJs': 'all'
     },
+    'hinting': (process.env.EMBER_ENV === 'test'),
     'cssModules': {
       'intermediateOutputPath': 'app/styles/app.scss',
       'extension': 'scss',


### PR DESCRIPTION
This disables the linter for everything but tests. That means that running
`ember serve` will no longer trigger linter warnings/errors. The reason for
this is that it takes a significant amount of time every time the server is
started.

`ember test` will still run the linter as part of the test suite; also hound
will still lint everything on GitHub.

I initially wanted to open a ticket for this, but decided to just create a PR
for it, so we can merge it if everyone is in favour.

So, @ebolloff, @eugenk opinions on this?