### PR TITLE
Add ember-page-title

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Ontohub</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/templates/application.emblem
+++ b/app/templates/application.emblem
@@ -1,3 +1,4 @@
+= title 'Ontohub' prepend=true separator=' · '
 = top-bar
 
 .page-wrapper

--- a/app/templates/namespace/show.emblem
+++ b/app/templates/namespace/show.emblem
@@ -1,1 +1,2 @@
+= title model.name
 = outlet

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-lodash": "0.0.11",
+    "ember-page-title": "3.0.10",
     "ember-resolver": "^2.0.3",
     "liquid-fire": "0.26.4",
     "loader.js": "^4.0.1",


### PR DESCRIPTION
Fixes #26. It uses a similar format to the current ontohub.org page.

Examples:
- Index page `/`: Ontohub
- Search page `/search`: Search · Ontohub
- Search term: `/search?q=foobar`: foobar · Search · Ontohub
- User page: `/foobar`: foobar · Ontohub
- Repository page: `/foobar/repo`: foobar/repo · Ontohub

This PR only implements the index page and the user page, as the other pages do not exist yet.