### PR TITLE
Configure headless Chrome test client

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -8,6 +8,19 @@ module.exports = {
   ],
   "launch_in_dev": [
     "PhantomJS",
+    "Chromium",
     "Chrome"
-  ]
+  ],
+  "browser_args": {
+    "Chromium": [
+      "--headless",
+      "--disable-gpu",
+      "--remote-debugging-port=9222"
+    ],
+    "Chrome": [
+      "--headless",
+      "--disable-gpu",
+      "--remote-debugging-port=9222"
+    ]
+  }
 };


### PR DESCRIPTION
Fixes #64. This uses PhantomJS during CI runs (`ember test`), as the chromium version used by Travis is too old and does not support the headless mode.
