### PR TITLE
76 remove semicolons where possible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,7 @@
     "one-var": ["error", "always"],
     "prefer-arrow-callback": ["warn", { "allowNamedFunctions": true }],
     "prefer-rest-params": ["error"],
+    "semi": ["warn", "never"],
     "semi-spacing": ["error"],
     "template-curly-spacing": ["error"]
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -44,6 +44,7 @@
     "prefer-rest-params": ["error"],
     "semi": ["warn", "never"],
     "semi-spacing": ["error"],
-    "template-curly-spacing": ["error"]
+    "template-curly-spacing": ["error"],
+    "quotes": ["warn", "single", { "avoidEscape": true }]
   }
 }

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,6 +1,6 @@
 import Ember from 'ember'
 import DS from 'ember-data'
-import ENV from "../config/environment"
+import ENV from '../config/environment'
 import SimpleAuthData from 'ember-simple-auth/mixins/data-adapter-mixin'
 const { underscore, pluralize } = Ember.String
 

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
-import DS from 'ember-data';
-import ENV from "../config/environment";
-import SimpleAuthData from 'ember-simple-auth/mixins/data-adapter-mixin';
-const { underscore, pluralize } = Ember.String;
+import Ember from 'ember'
+import DS from 'ember-data'
+import ENV from "../config/environment"
+import SimpleAuthData from 'ember-simple-auth/mixins/data-adapter-mixin'
+const { underscore, pluralize } = Ember.String
 
 export default DS.JSONAPIAdapter.extend(SimpleAuthData, {
   // if your rails app is on a different port from your ember app
@@ -12,8 +12,8 @@ export default DS.JSONAPIAdapter.extend(SimpleAuthData, {
 
   // allows the multiword paths in urls to be underscored
   pathForType: function(type) {
-    let underscored = underscore(type);
-    return pluralize(underscored);
+    let underscored = underscore(type)
+    return pluralize(underscored)
   },
   authorizer: 'authorizer:token'
-});
+})

--- a/app/adapters/repository.js
+++ b/app/adapters/repository.js
@@ -1,25 +1,25 @@
-import ApplicationAdapter from './application';
+import ApplicationAdapter from './application'
 
 export default ApplicationAdapter.extend({
   urlForFindRecord(id) {
-    return this._urlForRecord(id);
+    return this._urlForRecord(id)
   },
   urlForUpdateRecord(id) {
-    return this._urlForRecord(id);
+    return this._urlForRecord(id)
   },
   urlForDeleteRecord(id) {
-    return this._urlForRecord(id);
+    return this._urlForRecord(id)
   },
   _urlForRecord(id) {
     let host = this.get('host'),
-        url = `/repositories/${id}`;
+        url = `/repositories/${id}`
     /*
      * This is configuration specific and can't be tested
      */
     /* istanbul ignore else */
     if(host) {
-      url = `${host}${url}`;
+      url = `${host}${url}`
     }
-    return url;
+    return url
   }
-});
+})

--- a/app/adapters/search-result.js
+++ b/app/adapters/search-result.js
@@ -1,7 +1,7 @@
-import ApplicationAdapter from './application';
+import ApplicationAdapter from './application'
 
 export default ApplicationAdapter.extend({
   pathForType() {
-    return 'search';
+    return 'search'
   }
 })

--- a/app/adapters/version.js
+++ b/app/adapters/version.js
@@ -1,16 +1,16 @@
-import ApplicationAdapter from './application';
+import ApplicationAdapter from './application'
 
 export default ApplicationAdapter.extend({
   urlForFindRecord() {
     let host = this.get('host'),
-        url = '/version';
+        url = '/version'
     /*
      * This is configuration specific and can't be tested
      */
     /* istanbul ignore else */
     if(host) {
-      url = `${host}${url}`;
+      url = `${host}${url}`
     }
-    return url;
+    return url
   }
 })

--- a/app/app.js
+++ b/app/app.js
@@ -1,18 +1,18 @@
-import Ember from 'ember';
-import Resolver from './resolver';
-import loadInitializers from 'ember-load-initializers';
-import config from './config/environment';
+import Ember from 'ember'
+import Resolver from './resolver'
+import loadInitializers from 'ember-load-initializers'
+import config from './config/environment'
 
-let App;
+let App
 
-Ember.MODEL_FACTORY_INJECTIONS = true;
+Ember.MODEL_FACTORY_INJECTIONS = true
 
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver
-});
+})
 
-loadInitializers(App, config.modulePrefix);
+loadInitializers(App, config.modulePrefix)
 
-export default App;
+export default App

--- a/app/authenticators/jwt.js
+++ b/app/authenticators/jwt.js
@@ -1,4 +1,4 @@
-import Jwt from 'ember-simple-auth-token/authenticators/jwt';
+import Jwt from 'ember-simple-auth-token/authenticators/jwt'
 
 export default Jwt.extend({
   getAuthenticateData: /* istanbul ignore next */
@@ -9,8 +9,8 @@ export default Jwt.extend({
         [this.passwordField]: credentials.password,
         [this.identificationField]: credentials.identification
       }
-    };
+    }
 
-    return authentication;
+    return authentication
   }
-});
+})

--- a/app/components/app-footer.js
+++ b/app/components/app-footer.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   localClassNames: 'app-footer'
-});
+})

--- a/app/components/content-icon.js
+++ b/app/components/content-icon.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   tagName: 'img',
@@ -8,4 +8,4 @@ export default Ember.Component.extend({
     return this.get('iconImage') ?
       `/assets/${this.get('iconImage')}-icon.svg` : ''
   }),
-});
+})

--- a/app/components/inline-edit.js
+++ b/app/components/inline-edit.js
@@ -1,23 +1,22 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   localClassNames: 'inline-edit',
   actions: {
     enterEditing() {
-      this.set('isEditing', true);
+      this.set('isEditing', true)
       Ember.run.scheduleOnce('afterRender', this, function() {
-        // eslint-disable-next-line no-undef
-        $(`#${this.elementId} .input-group-field`).focus();
-      });
+        Ember.$(`#${this.elementId} .input-group-field`).focus()
+      })
     },
     exitEditing() {
-      this.set('isEditing', false);
-      this.sendAction('action', this.get('model'));
+      this.set('isEditing', false)
+      this.sendAction('action', this.get('model'))
     },
     cancelEditing() {
-      this.set('isEditing', false);
-      this.get('model').rollbackAttributes();
-      return false;
+      this.set('isEditing', false)
+      this.get('model').rollbackAttributes()
+      return false
     }
   }
-});
+})

--- a/app/components/organizational-unit.js
+++ b/app/components/organizational-unit.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   classNames: ['organizational-unit'],
   isUser: Ember.computed('orgUnit', function() {
-    return this.get('orgUnit').constructor.modelName === 'user';
+    return this.get('orgUnit').constructor.modelName === 'user'
   })
-});
+})

--- a/app/components/radio-choice.js
+++ b/app/components/radio-choice.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   localClassNames: 'radio-choice'
-});
+})

--- a/app/components/repository-component.js
+++ b/app/components/repository-component.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   classNames: ['repository']
-});
+})

--- a/app/components/search-result.js
+++ b/app/components/search-result.js
@@ -1,21 +1,21 @@
-import Ember from 'ember';
-import _ from 'lodash';
+import Ember from 'ember'
+import _ from 'lodash'
 
 const SearchResultComponent = Ember.Component.extend({
   localClassNames: 'search-result',
   icon: Ember.computed('params.[]', function() {
-    return this.get('params')[0];
+    return this.get('params')[0]
   }),
   title: Ember.computed('params.[]', function() {
-    return this.get('params')[1];
+    return this.get('params')[1]
   }),
   routeParams: Ember.computed('params.[]', function() {
-    return _.drop(this.get('params'), 2);
+    return _.drop(this.get('params'), 2)
   }),
-});
+})
 
 SearchResultComponent.reopenClass({
   positionalParams: 'params'
-});
+})
 
-export default SearchResultComponent;
+export default SearchResultComponent

--- a/app/components/top-bar.js
+++ b/app/components/top-bar.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   authenticatedUser: Ember.inject.service(),
@@ -11,25 +11,25 @@ export default Ember.Component.extend({
   actions: {
     signin() {
       let { identification,
-            password } = this.getProperties('identification', 'password');
+            password } = this.getProperties('identification', 'password')
       this.get('signInCallback')(identification, password,
-          (promise) => this.send('loading', promise));
+          (promise) => this.send('loading', promise))
     },
     signout() {
-      this.get('signOutCallback')(() => this.send('restoreDropDown'));
+      this.get('signOutCallback')(() => this.send('restoreDropDown'))
     },
     loading(data) {
-      this.set('isLoading', true);
+      this.set('isLoading', true)
       data.finally(() => {
-        this.set('isLoading', false);
-        this.send('restoreDropDown');
-      });
+        this.set('isLoading', false)
+        this.send('restoreDropDown')
+      })
     },
     restoreDropDown() {
       let dropDownElement =
-        Ember.$('.dropdown.menu > li.is-dropdown-submenu-parent.is-active');
-      dropDownElement.attr('data-is-click', false);
-      dropDownElement.removeClass('is-active');
+        Ember.$('.dropdown.menu > li.is-dropdown-submenu-parent.is-active')
+      dropDownElement.attr('data-is-click', false)
+      dropDownElement.removeClass('is-active')
     }
   }
-});
+})

--- a/app/components/top-bar.js
+++ b/app/components/top-bar.js
@@ -6,8 +6,8 @@ export default Ember.Component.extend({
   localClassNames: 'top-bar',
 
   isLoading: false,
-  identification: "ada",
-  password: "changeme",
+  identification: 'ada',
+  password: 'changeme',
   actions: {
     signin() {
       let { identification,

--- a/app/components/top-route-header.js
+++ b/app/components/top-route-header.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   classNames: 'top-route-header',
-});
+})

--- a/app/components/version-check.js
+++ b/app/components/version-check.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
   isIncompatible: Ember.computed('version', 'versionConfig', function() {

--- a/app/controllers/application-error.js
+++ b/app/controllers/application-error.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Controller.extend({
   actions: {
     back() {
-      history.back();
+      history.back()
     }
   }
-});
+})

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
-import config from  '../config/environment';
+import Ember from 'ember'
+import config from  '../config/environment'
 
 export default Ember.Controller.extend({
   session: Ember.inject.service(),
@@ -10,17 +10,17 @@ export default Ember.Controller.extend({
     function(identification, password, callback = null) {
       let credentials = { identification, password },
           promise =
-            this.get('session').authenticate('authenticator:jwt', credentials);
-      this.send('sessionChanged');
-      callback(promise);
+            this.get('session').authenticate('authenticator:jwt', credentials)
+      this.send('sessionChanged')
+      callback(promise)
     },
     signout: /* istanbul ignore next */
     // This is not testable, see `services/authenticated-user.js`
     function(callback = null) {
-      this.get('session').invalidate();
-      this.send('sessionChanged');
-      callback();
+      this.get('session').invalidate()
+      this.send('sessionChanged')
+      callback()
     }
   },
   versionConfig: config.versionConfig
-});
+})

--- a/app/controllers/organizational-unit/repository.js
+++ b/app/controllers/organizational-unit/repository.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Controller.extend({
   actions: {
     saveRepository(obj) {
-      obj.save();
+      obj.save()
     }
   }
-});
+})

--- a/app/controllers/organizational-unit/repository/new.js
+++ b/app/controllers/organizational-unit/repository/new.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Controller.extend({
   authenticatedUser: Ember.inject.service(),
@@ -6,19 +6,19 @@ export default Ember.Controller.extend({
   publicAccess: true,
   actions: {
     submitNewRepo: function() {
-      let repo = this.get('model');
+      let repo = this.get('model')
       this.get('authenticatedUser.authenticatedUser').then((user) => {
-        repo.set('owner', user);
-      });
-      repo.set('contentType', this.get('contentType'));
-      repo.set('publicAccess', this.get('publicAccess'));
+        repo.set('owner', user)
+      })
+      repo.set('contentType', this.get('contentType'))
+      repo.set('publicAccess', this.get('publicAccess'))
       repo.save().then((repo) => {
-        let _splitId = repo.id.split('/');
+        let _splitId = repo.id.split('/')
         this.transitionToRoute('organizationalUnit.repository.show',
           _splitId[0],
-          _splitId[1]);
-      });
-      return false;
+          _splitId[1])
+      })
+      return false
     }
   }
-});
+})

--- a/app/controllers/organizational-unit/repository/new.js
+++ b/app/controllers/organizational-unit/repository/new.js
@@ -2,7 +2,7 @@ import Ember from 'ember'
 
 export default Ember.Controller.extend({
   authenticatedUser: Ember.inject.service(),
-  contentType: "ontology",
+  contentType: 'ontology',
   publicAccess: true,
   actions: {
     submitNewRepo: function() {

--- a/app/controllers/organizational-unit/show.js
+++ b/app/controllers/organizational-unit/show.js
@@ -1,19 +1,19 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Controller.extend({
   queryParams: ['tab'],
   tab: 'repositories',
 
   tabRepositories: Ember.computed('tab', function() {
-    let tab = this.get('tab');
-    return (tab == 'repositories') || (tab == null);
+    let tab = this.get('tab')
+    return (tab == 'repositories') || (tab == null)
   }),
 
   tabMembers: Ember.computed('tab', function() {
-    return (this.get('tab') == 'members');
+    return (this.get('tab') == 'members')
   }),
 
   tabOrganizations: Ember.computed('tab', function() {
-    return (this.get('tab') == 'organizations');
+    return (this.get('tab') == 'organizations')
   })
-});
+})

--- a/app/controllers/search-result.js
+++ b/app/controllers/search-result.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Controller.extend({
   queryParams: ['type', 'q', 'content'],
@@ -7,15 +7,15 @@ export default Ember.Controller.extend({
   content: null,
 
   typeRepositories: Ember.computed('type', function() {
-    let type = this.get('type');
-    return (type == 'repositories') || (type == null);
+    let type = this.get('type')
+    return (type == 'repositories') || (type == null)
   }),
 
   typeOMS: Ember.computed('type', function() {
-    return (this.get('type') == 'oms');
+    return (this.get('type') == 'oms')
   }),
 
   typeUsers: Ember.computed('type', function() {
-    return (this.get('type') == 'users');
+    return (this.get('type') == 'users')
   })
-});
+})

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -1,11 +1,11 @@
-import DS from 'ember-data';
-import OrganizationalUnitModel from './organizational-unit';
+import DS from 'ember-data'
+import OrganizationalUnitModel from './organizational-unit'
 
-import schema from 'ontohub-frontend/schemas/models/organization_model';
-import { JsonSchemaModel } from 'ember-json-schema';
+import schema from 'ontohub-frontend/schemas/models/organization_model'
+import { JsonSchemaModel } from 'ember-json-schema'
 
-const schemaModel = JsonSchemaModel.generate(schema);
+const schemaModel = JsonSchemaModel.generate(schema)
 
 export default OrganizationalUnitModel.extend(schemaModel, {
   members: DS.hasMany('user')
-});
+})

--- a/app/models/organizational-unit.js
+++ b/app/models/organizational-unit.js
@@ -1,5 +1,5 @@
-import DS from 'ember-data';
+import DS from 'ember-data'
 
 export default DS.Model.extend({
   repositories: DS.hasMany('repository')
-});
+})

--- a/app/models/repository.js
+++ b/app/models/repository.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
-import DS from 'ember-data';
+import Ember from 'ember'
+import DS from 'ember-data'
 
-import schema from 'ontohub-frontend/schemas/models/repository_model';
-import { JsonSchemaModel } from 'ember-json-schema';
+import schema from 'ontohub-frontend/schemas/models/repository_model'
+import { JsonSchemaModel } from 'ember-json-schema'
 
-const schemaModel = JsonSchemaModel.generate(schema);
+const schemaModel = JsonSchemaModel.generate(schema)
 
 export default DS.Model.extend(schemaModel, {
   ownerUser: DS.belongsTo('user'),
@@ -12,23 +12,23 @@ export default DS.Model.extend(schemaModel, {
   owner: Ember.computed('ownerUser', 'ownerOrganization', {
     get() {
       if(this.get('ownerUser').content) {
-        return this.get('ownerUser');
+        return this.get('ownerUser')
       } else {
-        return this.get('ownerOrganization');
+        return this.get('ownerOrganization')
       }
     },
     set(key, value) {
       if(value.constructor.modelName === 'user') {
-        this.set('ownerUser', value);
+        this.set('ownerUser', value)
       } else if(value.constructor.modelName === 'organization') {
-        this.set('ownerOrganization', value);
+        this.set('ownerOrganization', value)
       }
 
-      return value;
+      return value
     }
   }),
   repoId: Ember.computed('id', function() {
-    let f = this.get('id').split('/');
-    return f[1];
+    let f = this.get('id').split('/')
+    return f[1]
   }),
-});
+})

--- a/app/models/search-result.js
+++ b/app/models/search-result.js
@@ -1,8 +1,8 @@
-import DS from 'ember-data';
+import DS from 'ember-data'
 
 export default DS.Model.extend({
   repositories: DS.hasMany('repository'),
   repositoriesCount: DS.attr('number'),
   organizationalUnits: DS.hasMany('organizationalUnit'),
   organizationalUnitsCount: DS.attr('number')
-});
+})

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,11 +1,11 @@
-import DS from 'ember-data';
-import OrganizationalUnitModel from './organizational-unit';
+import DS from 'ember-data'
+import OrganizationalUnitModel from './organizational-unit'
 
-import schema from 'ontohub-frontend/schemas/models/user_model';
-import { JsonSchemaModel } from 'ember-json-schema';
+import schema from 'ontohub-frontend/schemas/models/user_model'
+import { JsonSchemaModel } from 'ember-json-schema'
 
-const schemaModel = JsonSchemaModel.generate(schema);
+const schemaModel = JsonSchemaModel.generate(schema)
 
 export default OrganizationalUnitModel.extend(schemaModel, {
   organizations: DS.hasMany('organization')
-});
+})

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -1,8 +1,8 @@
-import DS from 'ember-data';
+import DS from 'ember-data'
 
 export default DS.Model.extend({
   commit: DS.attr('string'),
   commitsSinceTag: DS.attr('number'),
   full: DS.attr('string'),
   tag: DS.attr('string')
-});
+})

--- a/app/resolver.js
+++ b/app/resolver.js
@@ -1,3 +1,3 @@
-import Resolver from 'ember-resolver';
+import Resolver from 'ember-resolver'
 
-export default Resolver;
+export default Resolver

--- a/app/router.js
+++ b/app/router.js
@@ -1,24 +1,24 @@
-import Ember from 'ember';
-import config from './config/environment';
+import Ember from 'ember'
+import config from './config/environment'
 
 const Router = Ember.Router.extend({
   location: config.locationType,
   rootURL: config.rootURL
-});
+})
 
 Router.map(function() {
-  this.route('organizationalUnit.repository.new', { path: 'new' });
+  this.route('organizationalUnit.repository.new', { path: 'new' })
   this.route('organizationalUnit', {
     path: ':organizational_unit_id'
   }, function() {
-    this.route('show', { path: '' });
+    this.route('show', { path: '' })
 
     this.route('repository', { path: ':repository_id' }, function() {
-      this.route('show', { path: '' });
-    });
-  });
-  this.route('search-result', { path: 'search' });
-  this.route('login');
-});
+      this.route('show', { path: '' })
+    })
+  })
+  this.route('search-result', { path: 'search' })
+  this.route('login')
+})
 
-export default Router;
+export default Router

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,22 +1,22 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Route.extend({
   renderTemplate() {
-    this.render();
+    this.render()
     this.render('search/bar', {
       into: 'application',
       outlet: 'search-bar'
     })
   },
   model() {
-    return this.get('store').find('version', 'version');
+    return this.get('store').find('version', 'version')
   },
   actions: {
     sessionChanged: /* istanbul ignore next */
     // This is not testable, see `services/authenticated-user.js`
     function() {
-      this.store.unloadAll();
-      this.refresh();
+      this.store.unloadAll()
+      this.refresh()
     }
   }
-});
+})

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,11 +1,11 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Route.extend({
   renderTemplate() {
-    this.render('index/show');
+    this.render('index/show')
     this.render('index/header', {
       into: 'application',
       outlet: 'top-route-header'
     })
   }
-});
+})

--- a/app/routes/organizational-unit.js
+++ b/app/routes/organizational-unit.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Route.extend({
   model(params) {
-    return this.store.find('organizationalUnit', params.organizational_unit_id);
+    return this.store.find('organizationalUnit', params.organizational_unit_id)
   }
-});
+})

--- a/app/routes/organizational-unit/repository.js
+++ b/app/routes/organizational-unit/repository.js
@@ -1,17 +1,17 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Route.extend({
   model(params) {
     let orgUnit = this.modelFor('organizationalUnit'),
         repo_id = [orgUnit.id, params.repository_id].join('/'),
-        repo = this.store.find('repository', repo_id);
-    return repo;
+        repo = this.store.find('repository', repo_id)
+    return repo
   },
   renderTemplate() {
-    this.render();
+    this.render()
     this.render('organizational-unit/repository/header', {
       into: 'application',
       outlet: 'top-route-header'
     })
   }
-});
+})

--- a/app/routes/organizational-unit/repository/new.js
+++ b/app/routes/organizational-unit/repository/new.js
@@ -1,14 +1,14 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Route.extend({
   model() {
-    return this.store.createRecord('repository', {});
+    return this.store.createRecord('repository', {})
   },
   renderTemplate() {
-    this.render();
+    this.render()
     this.render('organizational-unit/repository/new-header', {
       into: 'application',
       outlet: 'top-route-header'
     })
   }
-});
+})

--- a/app/routes/organizational-unit/show.js
+++ b/app/routes/organizational-unit/show.js
@@ -1,22 +1,22 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Route.extend({
   renderTemplate(controller, model) {
     if(model.constructor.modelName === 'user'){
-      this.render('organizationalUnit/user/show');
+      this.render('organizationalUnit/user/show')
       this.render('organizationalUnit/user/header', {
         into: 'application',
         outlet: 'top-route-header'
-      });
+      })
     } else {
-      this.render('organizationalUnit/organization/show');
+      this.render('organizationalUnit/organization/show')
       this.render('organizationalUnit/organization/header', {
         into: 'application',
         outlet: 'top-route-header'
-      });
+      })
     }
   },
   resetController(controller) {
-    controller.set('tab', 'repositories');
+    controller.set('tab', 'repositories')
   }
-});
+})

--- a/app/routes/search-result.js
+++ b/app/routes/search-result.js
@@ -1,22 +1,22 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Route.extend({
   model() {
-    return this.get('store').queryRecord('search-result', { q: '' });
+    return this.get('store').queryRecord('search-result', { q: '' })
   },
   renderTemplate() {
-    this.render('search/show');
+    this.render('search/show')
     this.render('empty', {
       into: 'application',
       outlet: 'search-bar'
-    });
+    })
     this.render('search/header', {
       into: 'application',
       outlet: 'top-route-header'
-    });
+    })
   },
   resetController(controller) {
-    controller.set('type', null);
-    controller.set('q', null);
+    controller.set('type', null)
+    controller.set('q', null)
   }
-});
+})

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,13 +1,13 @@
-import Ember from 'ember';
-import DS from 'ember-data';
-const underscore = Ember.String.underscore;
+import Ember from 'ember'
+import DS from 'ember-data'
+const underscore = Ember.String.underscore
 
 export default DS.JSONAPISerializer.extend({
   keyForAttribute: function(attr) {
-    return underscore(attr);
+    return underscore(attr)
   },
 
   keyForRelationship: function(rawKey) {
-    return underscore(rawKey);
+    return underscore(rawKey)
   }
-});
+})

--- a/app/serializers/repository.js
+++ b/app/serializers/repository.js
@@ -1,17 +1,17 @@
-import ApplicationSerializer from './application';
-import _ from 'lodash';
+import ApplicationSerializer from './application'
+import _ from 'lodash'
 
 export default ApplicationSerializer.extend({
 
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     let data = payload.data,
-        isArray = true;
+        isArray = true
     if(!Array.isArray(data)) {
-      data = [payload.data];
-      isArray = false;
+      data = [payload.data]
+      isArray = false
     }
     data = _.map(data, (d) => {
-      let owner = d.relationships.owner;
+      let owner = d.relationships.owner
 
       /*
       * We can't test this with mirage, as we send `owner_user` or
@@ -19,41 +19,41 @@ export default ApplicationSerializer.extend({
       */
       /* istanbul ignore if */
       if(owner) {
-        let type = owner.data.type;
+        let type = owner.data.type
 
         if(type === 'users') {
-          d.relationships.owner_user = owner;
+          d.relationships.owner_user = owner
         } else if(type === 'organizations') {
-          d.relationships.owner_organization = owner;
+          d.relationships.owner_organization = owner
         }
 
-        delete d.relationships.owner;
+        delete d.relationships.owner
       }
 
-      return d;
-    });
+      return d
+    })
 
     if(!isArray) {
-      data = data[0];
+      data = data[0]
     }
 
-    payload.data = data;
+    payload.data = data
 
-    return this._super(store, primaryModelClass, payload, id, requestType);
+    return this._super(store, primaryModelClass, payload, id, requestType)
   },
   serialize(snapshot, options) {
     let json = this._super(snapshot, options),
         relationships = json.data.relationships,
-        owner;
+        owner
     if(relationships.owner_user && relationships.owner_user.data) {
-      owner = relationships.owner_user;
+      owner = relationships.owner_user
     } else {
-      owner = relationships.owner_organization;
+      owner = relationships.owner_organization
     }
 
-    relationships.owner = owner;
-    delete relationships.owner_user;
-    delete relationships.owner_organization;
-    return json;
+    relationships.owner = owner
+    delete relationships.owner_user
+    delete relationships.owner_organization
+    return json
   }
-});
+})

--- a/app/services/authenticated-user.js
+++ b/app/services/authenticated-user.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Service.extend({
   store: Ember.inject.service('store'),
@@ -6,7 +6,7 @@ export default Ember.Service.extend({
   tokenData: Ember.computed('session.data.authenticated', function() {
     let authenticator = Ember.getOwner(this).lookup('authenticator:jwt'),
         session = this.get('session.data.authenticated.data.attributes'),
-        tokenData = {};
+        tokenData = {}
 
     /*
      * We can't test the sessions directly because of problems with the mirage
@@ -14,12 +14,12 @@ export default Ember.Service.extend({
      */
     /* istanbul ignore else */
     if(session && Object.keys(session).length > 0) {
-      tokenData = authenticator.getTokenData(session.token);
+      tokenData = authenticator.getTokenData(session.token)
     }
 
-    return tokenData;
+    return tokenData
   }),
   authenticatedUser: Ember.computed('tokenData', function() {
-    return this.get('store').find('user', this.get('tokenData.user_id'));
+    return this.get('store').find('user', this.get('tokenData.user_id'))
   })
-});
+})

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -2,5 +2,5 @@ export default function() {
   this.transition(
     this.outletName('top-route-header'),
     this.use('fade', { duration: 100 })
-  );
+  )
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,8 +1,7 @@
 /* eslint-env node */
-/* eslint no-var: "off" */
 
 module.exports = function(environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: 'ontohub-frontend',
     environment: environment,
     rootURL: '/',
@@ -18,13 +17,13 @@ module.exports = function(environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     }
-  };
+  }
 
   if (environment === 'development') {
-    ENV.host = 'http://localhost:3000';
+    ENV.host = 'http://localhost:3000'
     ENV['ember-cli-mirage'] = {
       enabled: false
-    };
+    }
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -36,26 +35,26 @@ module.exports = function(environment) {
       commitsSinceTagMax: null,
       commit: null,
       full: null
-    };
+    }
   }
 
   if (environment === 'test') {
     // Testem prefers this...
     ENV.host = 'http://localhost:3000'
-    ENV.locationType = 'none';
+    ENV.locationType = 'none'
 
     // keep test console output quieter
-    ENV.APP.LOG_ACTIVE_GENERATION = false;
-    ENV.APP.LOG_VIEW_LOOKUPS = false;
+    ENV.APP.LOG_ACTIVE_GENERATION = false
+    ENV.APP.LOG_VIEW_LOOKUPS = false
 
-    ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.rootElement = '#ember-testing'
     ENV.versionConfig = {
       tag: '0.0.0',
       commitsSinceTagMin: 65,
       commitsSinceTagMax: null,
       commit: null,
       full: null
-    };
+    }
   }
 
   if (environment === 'production') {
@@ -65,7 +64,7 @@ module.exports = function(environment) {
       commitsSinceTagMax: null,
       commit: null,
       full: null
-    };
+    }
   }
 
   ENV['ember-simple-auth-token'] = {
@@ -76,7 +75,7 @@ module.exports = function(environment) {
 
   ENV['ember-simple-auth'] = {
     authorizer: 'authorizer:token'
-  };
+  }
 
-  return ENV;
-};
+  return ENV
+}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,9 +1,8 @@
-/* eslint-disable no-undef */
-/* global require, module */
-var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+/* eslint-env node */
+let EmberApp = require('ember-cli/lib/broccoli/ember-app')
 
 module.exports = function(defaults) {
-  var app = new EmberApp(defaults, {
+  let app = new EmberApp(defaults, {
     // Add options here
     'babel': {
       'optional': ['es6.spec.symbols'],
@@ -22,7 +21,7 @@ module.exports = function(defaults) {
         'syntax': require('postcss-scss')
       }
     }
-  });
+  })
 
   // Use `app.import` to add additional libraries to the generated
   // output files.
@@ -37,5 +36,5 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-  return app.toTree();
-};
+  return app.toTree()
+}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,19 +1,19 @@
-import _ from 'lodash';
+import _ from 'lodash'
 
 export default function() {
-  this.passthrough('/write-coverage');
+  this.passthrough('/write-coverage')
 
-  this.urlPrefix = 'http://localhost:3000';
+  this.urlPrefix = 'http://localhost:3000'
 
   // this.namespace = '';
   // this.timing = 400;
 
   this.get('/organizational_units/:id', (schema, request) => {
     let user = schema.users.find(request.params.id),
-        organization = schema.organizations.find(request.params.id);
+        organization = schema.organizations.find(request.params.id)
 
-    return organization || user;
-  });
+    return organization || user
+  })
 
   this.get('/version', () => ({
     data: {
@@ -26,7 +26,7 @@ export default function() {
       id: 'version',
       type: 'versions'
     }
-  }));
+  }))
 
   this.get('/search', function(schema) {
     let users = this.serialize(schema.users.all()).data,
@@ -44,16 +44,16 @@ export default function() {
         },
         result = this.serialize(schema.searchResults.new(attributes)),
         relOrganizations = result.data.relationships.organizations,
-        relUsers = result.data.relationships.users;
+        relUsers = result.data.relationships.users
     result.data.relationships.organizational_units = {
       data: _.concat(relUsers.data, relOrganizations.data)
-    };
-    delete result.data.relationships.users;
-    delete result.data.relationships.organizations;
-    return result;
-  });
+    }
+    delete result.data.relationships.users
+    delete result.data.relationships.organizations
+    return result
+  })
 
-  this.post('/users');
+  this.post('/users')
   this.post('/users/sign_in', () => ({
     data: {
       attributes: {
@@ -66,59 +66,59 @@ export default function() {
     jsonapi: {
       version: '1.0'
     }
-  }));
-  this.get('/users/:id');
-  this.del('/users/:id');
-  this.put('/users/:id');
+  }))
+  this.get('/users/:id')
+  this.del('/users/:id')
+  this.put('/users/:id')
 
-  this.post('/organizations');
-  this.get('/organizations/:id');
-  this.del('/organizations/:id');
-  this.put('/organizations/:id');
+  this.post('/organizations')
+  this.get('/organizations/:id')
+  this.del('/organizations/:id')
+  this.put('/organizations/:id')
 
   this.post('/repositories', function(schema, request) {
     let originalRequest = JSON.parse(request.requestBody),
         owner = originalRequest.data.relationships.owner.data,
         attrs = this.normalizedRequestAttrs(),
-        slug = attrs.name.split(' ').join('-');
+        slug = attrs.name.split(' ').join('-')
 
-    attrs.id = `${owner.id}/${slug}`;
+    attrs.id = `${owner.id}/${slug}`
 
     if (owner.type === 'users') {
-      attrs.ownerUserId = owner.id;
+      attrs.ownerUserId = owner.id
     } else if (owner.type === 'organizations') {
-      attrs.ownerOrganizationId = owner.id;
+      attrs.ownerOrganizationId = owner.id
     }
-    delete attrs.ownerId;
+    delete attrs.ownerId
 
-    return schema.repositories.create(attrs);
-  });
+    return schema.repositories.create(attrs)
+  })
   this.get('/repositories/:orgUnit/:id', (schema, request) => {
     let repoId = [request.params.orgUnit, request.params.id].join('/'),
-        repository = schema.repositories.find(repoId);
+        repository = schema.repositories.find(repoId)
 
-    return repository;
-  });
+    return repository
+  })
   this.del('/repositories/:orgUnit/:id', (schema, request) => {
-    let repoId = [request.params.orgUnit, request.params.id].join('/');
-    schema.repositories.find(repoId).destroy();
-  });
+    let repoId = [request.params.orgUnit, request.params.id].join('/')
+    schema.repositories.find(repoId).destroy()
+  })
   this.patch('/repositories/:orgUnit/:id', function(schema, request) {
     let repoId = [request.params.orgUnit, request.params.id].join('/'),
         repo = schema.repositories.find(repoId),
-        attrs = this.normalizedRequestAttrs();
+        attrs = this.normalizedRequestAttrs()
 
     if (repo.ownerUserId) {
-      attrs.ownerUserId = repo.ownerUserId;
+      attrs.ownerUserId = repo.ownerUserId
     } else if (repo.ownerOrganizationId) {
-      attrs.ownerOrganizationId = repo.ownerUserId;
+      attrs.ownerOrganizationId = repo.ownerUserId
     }
 
-    delete attrs.ownerId;
-    attrs.id = repo.id;
+    delete attrs.ownerId
+    attrs.id = repo.id
 
-    return repo.update(attrs);
-  });
+    return repo.update(attrs)
+  })
 
   /*
     Shorthand cheatsheet:

--- a/mirage/factories/organization.js
+++ b/mirage/factories/organization.js
@@ -1,16 +1,16 @@
-import { Factory, faker } from 'ember-cli-mirage';
-import _ from 'lodash';
+import { Factory, faker } from 'ember-cli-mirage'
+import _ from 'lodash'
 
-import SchemaFactory from 'ember-json-schema/mirage/factory';
-import schema from 'ontohub-frontend/schemas/models/organization_model';
+import SchemaFactory from 'ember-json-schema/mirage/factory'
+import schema from 'ontohub-frontend/schemas/models/organization_model'
 
-const schemaModel = SchemaFactory.generate(schema);
+const schemaModel = SchemaFactory.generate(schema)
 
 export default Factory.extend(Object.assign({}, schemaModel, {
   name(i) {
-    return `Organization ${i}`;
+    return `Organization ${i}`
   },
   id() {
-    return faker.helpers.slugify(_.lowerCase(this.name));
+    return faker.helpers.slugify(_.lowerCase(this.name))
   }
-}));
+}))

--- a/mirage/factories/repository.js
+++ b/mirage/factories/repository.js
@@ -1,16 +1,16 @@
-import { Factory, faker } from 'ember-cli-mirage';
-import _ from 'lodash';
+import { Factory, faker } from 'ember-cli-mirage'
+import _ from 'lodash'
 
-import SchemaFactory from 'ember-json-schema/mirage/factory';
-import schema from 'ontohub-frontend/schemas/models/repository_model';
+import SchemaFactory from 'ember-json-schema/mirage/factory'
+import schema from 'ontohub-frontend/schemas/models/repository_model'
 
-const schemaModel = SchemaFactory.generate(schema);
+const schemaModel = SchemaFactory.generate(schema)
 
 export default Factory.extend(
   Object.assign({}, schemaModel, {
     id() {
-      let slug = faker.helpers.slugify(_.lowerCase(this.name));
-      return `${this.ownerUserId || this.ownerOrganizationId}/${slug}`;
+      let slug = faker.helpers.slugify(_.lowerCase(this.name))
+      return `${this.ownerUserId || this.ownerOrganizationId}/${slug}`
     }
   })
-);
+)

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -1,16 +1,16 @@
-import { Factory, faker } from 'ember-cli-mirage';
-import _ from 'lodash';
+import { Factory, faker } from 'ember-cli-mirage'
+import _ from 'lodash'
 
-import SchemaFactory from 'ember-json-schema/mirage/factory';
-import schema from 'ontohub-frontend/schemas/models/user_model';
+import SchemaFactory from 'ember-json-schema/mirage/factory'
+import schema from 'ontohub-frontend/schemas/models/user_model'
 
-const schemaModel = SchemaFactory.generate(schema);
+const schemaModel = SchemaFactory.generate(schema)
 
 export default Factory.extend(Object.assign({}, schemaModel, {
   name(i) {
     return `User ${i}`
   },
   id() {
-    return faker.helpers.slugify(_.lowerCase(this.name));
+    return faker.helpers.slugify(_.lowerCase(this.name))
   }
-}));
+}))

--- a/mirage/models/organization.js
+++ b/mirage/models/organization.js
@@ -1,6 +1,6 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, hasMany } from 'ember-cli-mirage'
 
 export default Model.extend({
   members: hasMany('user'),
   repositories: hasMany('repository')
-});
+})

--- a/mirage/models/repository.js
+++ b/mirage/models/repository.js
@@ -1,6 +1,6 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { Model, belongsTo } from 'ember-cli-mirage'
 
 export default Model.extend({
   ownerOrganization: belongsTo('organization'),
   ownerUser: belongsTo('user')
-});
+})

--- a/mirage/models/search-result.js
+++ b/mirage/models/search-result.js
@@ -1,7 +1,7 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, hasMany } from 'ember-cli-mirage'
 
 export default Model.extend({
   repositories: hasMany('repository'),
   users: hasMany('user'),
   organizations: hasMany('organization')
-});
+})

--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -1,6 +1,6 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, hasMany } from 'ember-cli-mirage'
 
 export default Model.extend({
   organizations: hasMany('organization'),
   repositories: hasMany('repository')
-});
+})

--- a/mirage/models/version.js
+++ b/mirage/models/version.js
@@ -1,4 +1,4 @@
-import { Model } from 'ember-cli-mirage';
+import { Model } from 'ember-cli-mirage'
 
 export default Model.extend({
-});
+})

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -1,13 +1,13 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
-import Ember from 'ember';
-const underscore = Ember.String.underscore;
+import { JSONAPISerializer } from 'ember-cli-mirage'
+import Ember from 'ember'
+const underscore = Ember.String.underscore
 
 export default JSONAPISerializer.extend({
   keyForAttribute: function(attr) {
-    return underscore(attr);
+    return underscore(attr)
   },
 
   keyForRelationship: function(rawKey) {
-    return underscore(rawKey);
+    return underscore(rawKey)
   }
-});
+})

--- a/mirage/serializers/namespace.js
+++ b/mirage/serializers/namespace.js
@@ -1,5 +1,5 @@
-import Serializer from './application';
+import Serializer from './application'
 
 export default Serializer.extend({
   include: ['repositories']
-});
+})

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,5 @@
-/*jshint node:true*/
+/* eslint-env node */
+
 module.exports = {
   "framework": "mocha",
   "test_page": "tests/index.html?hidepassed",
@@ -23,4 +24,4 @@ module.exports = {
       "--remote-debugging-port=9222"
     ]
   }
-};
+}

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,38 +1,38 @@
-import { describe, it, beforeEach, afterEach } from 'mocha';
-import { expect } from 'chai';
-import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import { expect } from 'chai'
+import startApp from '../helpers/start-app'
+import destroyApp from '../helpers/destroy-app'
 
 describe('Acceptance | index', () => {
-  let application;
+  let application
 
   beforeEach(() => {
-    application = startApp();
-    visit('/');
-  });
+    application = startApp()
+    visit('/')
+  })
 
   afterEach(() => {
-    destroyApp(application);
-  });
+    destroyApp(application)
+  })
 
   it('can visit /', () => {
-    expect(currentURL()).to.equal('/');
-  });
+    expect(currentURL()).to.equal('/')
+  })
 
   it('shows the welcome message', () => {
     const header = find('.top-route-header'),
           heading = find('h1', header),
-          subheading = find('p.help-text', header);
+          subheading = find('p.help-text', header)
 
-    expect(heading.text()).to.equal('Welcome to Ontohub!');
+    expect(heading.text()).to.equal('Welcome to Ontohub!')
     // eslint-disable-next-line max-len
-    expect(subheading.text()).to.equal('Repositories and proof tools for Ontologies, Models and Specifications (OMS)');
-  });
+    expect(subheading.text()).to.equal('Repositories and proof tools for Ontologies, Models and Specifications (OMS)')
+  })
 
   it('shows the development note', () => {
     const warning = find('.page-content .warning.callout'),
-          heading = find('h4', warning);
+          heading = find('h4', warning)
 
-    expect(heading.text()).to.equal('Please note:');
-  });
-});
+    expect(heading.text()).to.equal('Please note:')
+  })
+})

--- a/tests/acceptance/organization-test.js
+++ b/tests/acceptance/organization-test.js
@@ -1,19 +1,19 @@
-import { describe, it, beforeEach, afterEach } from 'mocha';
-import _ from 'lodash';
-import { expect } from 'chai';
-import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import _ from 'lodash'
+import { expect } from 'chai'
+import startApp from '../helpers/start-app'
+import destroyApp from '../helpers/destroy-app'
 
 describe('Acceptance | organization', () => {
-  let application;
+  let application
 
   beforeEach(() => {
-    application = startApp();
-  });
+    application = startApp()
+  })
 
   afterEach(() => {
-    destroyApp(application);
-  });
+    destroyApp(application)
+  })
 
   describe('Organization page', () => {
     beforeEach(function() {
@@ -32,59 +32,59 @@ describe('Acceptance | organization', () => {
               memberCount,
               repositories,
               repositoryCount
-            };
-      Object.assign(this.currentTest, testData);
-      visit(`/${organization.id}`);
-    });
+            }
+      Object.assign(this.currentTest, testData)
+      visit(`/${organization.id}`)
+    })
 
     it('displays general organization information', function() {
       const header = find('.top-route-header'),
-            username = find('h1', header).text();
+            username = find('h1', header).text()
 
-      expect(username).to.equal(this.test.organization.name);
-    });
+      expect(username).to.equal(this.test.organization.name)
+    })
 
     it('displays the number of repositories and members', function() {
       const tabs = find('.top-route-header .tabs'),
             repositoryTab = find('li:contains(Repositories)', tabs).text(),
-            membersTab = find('li:contains(Members)', tabs).text();
+            membersTab = find('li:contains(Members)', tabs).text()
 
-      expect(repositoryTab).to.contain(this.test.repositoryCount);
-      expect(membersTab).to.contain(this.test.memberCount);
-    });
+      expect(repositoryTab).to.contain(this.test.repositoryCount)
+      expect(membersTab).to.contain(this.test.memberCount)
+    })
 
     it('displays the repositories', function() {
-      const container = find('.page-content');
+      const container = find('.page-content')
 
-      expect(container.children()).to.have.length(this.test.repositoryCount);
+      expect(container.children()).to.have.length(this.test.repositoryCount)
       _.map(_.zip(container.children(), this.test.repositories), (e) => {
-        expect(find('h1', e[0]).text()).to.contain(e[1].name);
-        expect(find('p.help-text', e[0]).text()).to.contain(e[1].description);
-      });
-    });
+        expect(find('h1', e[0]).text()).to.contain(e[1].name)
+        expect(find('p.help-text', e[0]).text()).to.contain(e[1].description)
+      })
+    })
 
     it('displays the members', function() {
-      const membersTab = find('.top-route-header .tabs a:contains(Members)');
-      click(membersTab);
+      const membersTab = find('.top-route-header .tabs a:contains(Members)')
+      click(membersTab)
       andThen(() => {
-        const container = find('.page-content');
+        const container = find('.page-content')
 
-        expect(container.children()).to.have.length(this.test.memberCount);
+        expect(container.children()).to.have.length(this.test.memberCount)
         _.map(_.zip(container.children(), this.test.members), (e) => {
-          expect(find('h1', e[0]).text()).to.contain(e[1].name);
-        });
-      });
-    });
+          expect(find('h1', e[0]).text()).to.contain(e[1].name)
+        })
+      })
+    })
 
     it('resets the tabs correctly upon re-entering page', function() {
-      const membersTab = find('.top-route-header .tabs a:contains(Members)');
-      click(membersTab);
-      click(`.page-content a:contains(${this.test.members[0].name})`);
-      click('a:contains(Organizations)');
-      click(`.page-content a:contains(${this.test.organization.name})`);
+      const membersTab = find('.top-route-header .tabs a:contains(Members)')
+      click(membersTab)
+      click(`.page-content a:contains(${this.test.members[0].name})`)
+      click('a:contains(Organizations)')
+      click(`.page-content a:contains(${this.test.organization.name})`)
       andThen(() => {
-        expect(currentURL()).to.equal(`/${this.test.organization.id}`);
-      });
-    });
-  });
-});
+        expect(currentURL()).to.equal(`/${this.test.organization.id}`)
+      })
+    })
+  })
+})

--- a/tests/acceptance/repository-test.js
+++ b/tests/acceptance/repository-test.js
@@ -1,19 +1,19 @@
-import { describe, it, beforeEach, afterEach } from 'mocha';
-import { expect } from 'chai';
-import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
-import { signIn } from '../helpers/session';
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import { expect } from 'chai'
+import startApp from '../helpers/start-app'
+import destroyApp from '../helpers/destroy-app'
+import { signIn } from '../helpers/session'
 
 describe('Acceptance | repository', () => {
-  let application;
+  let application
 
   beforeEach(() => {
-    application = startApp();
-  });
+    application = startApp()
+  })
 
   afterEach(() => {
-    destroyApp(application);
-  });
+    destroyApp(application)
+  })
 
   describe('Repository page', () => {
     beforeEach(function() {
@@ -22,67 +22,67 @@ describe('Acceptance | repository', () => {
             testData = {
               user,
               repository
-            };
-      Object.assign(this.currentTest, testData);
-      visit(`/${repository.id}`);
-    });
+            }
+      Object.assign(this.currentTest, testData)
+      visit(`/${repository.id}`)
+    })
 
     it('displays general repository information', function() {
       const header = find('.top-route-header'),
             name = find('h1', header),
-            description = find('span', header);
+            description = find('span', header)
 
       expect(name.text()).to.equal(
         `${this.test.user.name} / ${this.test.repository.name}`
-      );
-      expect(description.text()).to.equal(this.test.repository.description);
-    });
+      )
+      expect(description.text()).to.equal(this.test.repository.description)
+    })
 
     it('can change the repository description', function() {
       const header = find('.top-route-header'),
             description = find('span', header),
-            newDescription = 'This is the new description';
+            newDescription = 'This is the new description'
 
-      expect(description.text()).to.equal(this.test.repository.description);
-      click(description);
-      fillIn('.top-route-header form input', newDescription);
-      click('.top-route-header form button');
+      expect(description.text()).to.equal(this.test.repository.description)
+      click(description)
+      fillIn('.top-route-header form input', newDescription)
+      click('.top-route-header form button')
       andThen(() => {
-        expect(find('span', header).text()).to.equal(newDescription);
-      });
-    });
-  });
+        expect(find('span', header).text()).to.equal(newDescription)
+      })
+    })
+  })
 
   describe('New repository page', () => {
     beforeEach(function() {
-      this.currentTest.user = server.create('user', { name: 'Ada' });
-      signIn(application);
-      visit('/new');
-    });
+      this.currentTest.user = server.create('user', { name: 'Ada' })
+      signIn(application)
+      visit('/new')
+    })
 
     it('displays the available namespaces', function() {
-      const namespaceField = find('#repository-new-name select');
-      expect(namespaceField.text()).to.equal(this.test.user.name);
-    });
+      const namespaceField = find('#repository-new-name select')
+      expect(namespaceField.text()).to.equal(this.test.user.name)
+    })
 
     it('creates a new repository and redirects', function() {
       const name = 'some repo',
             description = 'This is the repository description',
-            expectedId = `${this.test.user.id}/some-repo`;
-      fillIn('#repository-new-name input', name);
-      fillIn('#repository-new-description input', description);
-      click('label:contains(Model)');
-      click('label:contains(Private)');
-      click('#repository-new-submit button');
+            expectedId = `${this.test.user.id}/some-repo`
+      fillIn('#repository-new-name input', name)
+      fillIn('#repository-new-description input', description)
+      click('label:contains(Model)')
+      click('label:contains(Private)')
+      click('#repository-new-submit button')
       andThen(() => {
-        const repo = server.db.repositories[0];
-        expect(repo.contentType).to.equal('model');
-        expect(repo.publicAccess).to.be.false;
-        expect(repo.name).to.equal(name);
-        expect(repo.id).to.equal(expectedId);
-        expect(repo.description).to.equal('This is the repository description');
-        expect(currentURL()).to.equal(`/${expectedId}`);
-      });
-    });
-  });
-});
+        const repo = server.db.repositories[0]
+        expect(repo.contentType).to.equal('model')
+        expect(repo.publicAccess).to.be.false
+        expect(repo.name).to.equal(name)
+        expect(repo.id).to.equal(expectedId)
+        expect(repo.description).to.equal('This is the repository description')
+        expect(currentURL()).to.equal(`/${expectedId}`)
+      })
+    })
+  })
+})

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -1,19 +1,19 @@
-import { describe, it, beforeEach, afterEach } from 'mocha';
-import { expect } from 'chai';
-import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
-import _ from 'lodash';
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import { expect } from 'chai'
+import startApp from '../helpers/start-app'
+import destroyApp from '../helpers/destroy-app'
+import _ from 'lodash'
 
 describe('Acceptance | search', () => {
-  let application;
+  let application
 
   beforeEach(() => {
-    application = startApp();
-  });
+    application = startApp()
+  })
 
   afterEach(() => {
-    destroyApp(application);
-  });
+    destroyApp(application)
+  })
 
   describe('Search page', () => {
     beforeEach(function() {
@@ -40,58 +40,58 @@ describe('Acceptance | search', () => {
               organizationalUnits: _.concat(users, organizations),
               repositoryCount,
               repositories: _.concat(userRepositories, organizationRepositories)
-            };
-      Object.assign(this.currentTest, testData);
-      visit('/search');
-    });
+            }
+      Object.assign(this.currentTest, testData)
+      visit('/search')
+    })
 
     it('displays general search information', () => {
       const header = find('.top-route-header'),
-            name = find('h1', header);
+            name = find('h1', header)
 
-      expect(name.text()).to.equal('All repositories');
-    });
+      expect(name.text()).to.equal('All repositories')
+    })
 
     it('shows the found repositories', function() {
-      const results = find('#results');
+      const results = find('#results')
 
-      expect(results.children()).to.have.length(this.test.repositoryCount);
-      let repoNames = _.map(this.test.repositories, (r) => r.attrs.id);
+      expect(results.children()).to.have.length(this.test.repositoryCount)
+      let repoNames = _.map(this.test.repositories, (r) => r.attrs.id)
       _.map(results.children(), (r) => {
         // Extract repository name without 'Private' if repository is private
-        let name = find('h1 a', r)[0].childNodes[0].nodeValue;
-        expect(name).to.be.oneOf(repoNames);
-      });
-    });
+        let name = find('h1 a', r)[0].childNodes[0].nodeValue
+        expect(name).to.be.oneOf(repoNames)
+      })
+    })
 
     it('shows that no OMS were found', () => {
-      click('a:contains(OMS)');
+      click('a:contains(OMS)')
 
       andThen(() => {
-        const results = find('#results');
+        const results = find('#results')
 
-        expect(results.text()).to.equal('No OMS found.');
-      });
-    });
+        expect(results.text()).to.equal('No OMS found.')
+      })
+    })
 
     it('shows the found organizational units', function() {
-      click('a:contains(Users)');
+      click('a:contains(Users)')
       andThen(() => {
-        const results = find('#results');
+        const results = find('#results')
 
         expect(results.children()).to.have.length(
           this.test.organizationalUnitCount
-        );
-      });
-    });
+        )
+      })
+    })
 
     it('resets the tabs correctly upon re-entering page', () => {
-      click('a:contains(Users)');
-      click('a:contains(Ontohub)');
-      click('a:contains(Search)');
+      click('a:contains(Users)')
+      click('a:contains(Ontohub)')
+      click('a:contains(Search)')
       andThen(() => {
-        expect(currentURL()).to.equal('/search');
-      });
-    });
-  });
-});
+        expect(currentURL()).to.equal('/search')
+      })
+    })
+  })
+})

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -1,19 +1,19 @@
-import { describe, it, beforeEach, afterEach } from 'mocha';
-import _ from 'lodash';
-import { expect } from 'chai';
-import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import _ from 'lodash'
+import { expect } from 'chai'
+import startApp from '../helpers/start-app'
+import destroyApp from '../helpers/destroy-app'
 
 describe('Acceptance | user', () => {
-  let application;
+  let application
 
   beforeEach(() => {
-    application = startApp();
-  });
+    application = startApp()
+  })
 
   afterEach(() => {
-    destroyApp(application);
-  });
+    destroyApp(application)
+  })
 
   describe('User page', () => {
     beforeEach(function() {
@@ -34,67 +34,67 @@ describe('Acceptance | user', () => {
               organizationCount,
               repositories,
               repositoryCount
-            };
-      Object.assign(this.currentTest, testData);
-      visit(`/${user.id}`);
-    });
+            }
+      Object.assign(this.currentTest, testData)
+      visit(`/${user.id}`)
+    })
 
     it('displays general user information', function() {
       const header = find('.top-route-header'),
             realname = find('h1', header),
-            username = find('h2', header);
+            username = find('h2', header)
 
-      expect(username.text()).to.equal(this.test.user.name);
-      expect(realname.text()).to.equal(this.test.user.real_name);
-    });
+      expect(username.text()).to.equal(this.test.user.name)
+      expect(realname.text()).to.equal(this.test.user.real_name)
+    })
 
     it('displays the number of repositories and organizations', function() {
       const tabs = find('.top-route-header .tabs'),
             repositoryTab = find('li:contains(Repositories)', tabs),
-            organizationsTab = find('li:contains(Organizations)', tabs);
+            organizationsTab = find('li:contains(Organizations)', tabs)
 
-      expect(repositoryTab.text()).to.contain(this.test.repositoryCount);
-      expect(organizationsTab.text()).to.contain(this.test.organizationCount);
-    });
+      expect(repositoryTab.text()).to.contain(this.test.repositoryCount)
+      expect(organizationsTab.text()).to.contain(this.test.organizationCount)
+    })
 
     it('displays the repositories', function() {
-      const container = find('.page-content');
+      const container = find('.page-content')
 
-      expect(container.children()).to.have.length(this.test.repositoryCount);
+      expect(container.children()).to.have.length(this.test.repositoryCount)
       _.map(_.zip(container.children(), this.test.repositories), (e) => {
-        expect(find('h1', e[0]).text()).to.contain(e[1].name);
-        expect(find('p.help-text', e[0]).text()).to.contain(e[1].description);
-      });
-    });
+        expect(find('h1', e[0]).text()).to.contain(e[1].name)
+        expect(find('p.help-text', e[0]).text()).to.contain(e[1].description)
+      })
+    })
 
     it('displays the organizations', function() {
       const organizationsTab = find(
         '.top-route-header .tabs a:contains(Organizations)'
-      );
-      click(organizationsTab);
+      )
+      click(organizationsTab)
       andThen(() => {
-        const container = find('.page-content');
+        const container = find('.page-content')
 
         expect(container.children()).to.have.length(
           this.test.organizationCount
-        );
+        )
         _.map(_.zip(container.children(), this.test.organizations), (e) => {
-          expect(find('h1', e[0]).text()).to.contain(e[1].name);
-        });
-      });
-    });
+          expect(find('h1', e[0]).text()).to.contain(e[1].name)
+        })
+      })
+    })
 
     it('resets the tabs correctly upon re-entering page', function() {
       const organizationsTab = find(
         '.top-route-header .tabs a:contains(Organizations)'
-      );
-      click(organizationsTab);
-      click(`.page-content a:contains(${this.test.organizations[0].name})`);
-      click('a:contains(Members)');
-      click(`.page-content a:contains(${this.test.user.name})`);
+      )
+      click(organizationsTab)
+      click(`.page-content a:contains(${this.test.organizations[0].name})`)
+      click('a:contains(Members)')
+      click(`.page-content a:contains(${this.test.user.name})`)
       andThen(() => {
-        expect(currentURL()).to.equal(`/${this.test.user.id}`);
-      });
-    });
-  });
-});
+        expect(currentURL()).to.equal(`/${this.test.user.id}`)
+      })
+    })
+  })
+})

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Ember from 'ember'
 // import { server } from 'ember-cli-mirage';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
-  server.shutdown();
+  Ember.run(application, 'destroy')
+  server.shutdown()
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,24 +1,24 @@
-import { module } from 'qunit';
-import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import destroyApp from '../helpers/destroy-app';
+import { module } from 'qunit'
+import Ember from 'ember'
+import startApp from '../helpers/start-app'
+import destroyApp from '../helpers/destroy-app'
 
-const { RSVP: { Promise } } = Ember;
+const { RSVP: { Promise } } = Ember
 
 export default function(name, options = {}) {
   module(name, {
     beforeEach(...args) {
-      this.application = startApp();
+      this.application = startApp()
 
       if (options.beforeEach) {
-        return options.beforeEach.apply(this, args);
+        return options.beforeEach.apply(this, args)
       }
     },
 
     afterEach(...args) {
-      let afterEach = options.afterEach && options.afterEach.apply(this, args);
+      let afterEach = options.afterEach && options.afterEach.apply(this, args)
       return Promise.resolve(afterEach)
-        .then(() => destroyApp(this.application));
+        .then(() => destroyApp(this.application))
     }
-  });
+  })
 }

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,11 +1,11 @@
-import Resolver from '../../resolver';
-import config from '../../config/environment';
+import Resolver from '../../resolver'
+import config from '../../config/environment'
 
-const resolver = Resolver.create();
+const resolver = Resolver.create()
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix
-};
+}
 
-export default resolver;
+export default resolver

--- a/tests/helpers/session.js
+++ b/tests/helpers/session.js
@@ -1,9 +1,9 @@
 import {
   authenticateSession
-} from 'ontohub-frontend/tests/helpers/ember-simple-auth';
+} from 'ontohub-frontend/tests/helpers/ember-simple-auth'
 
 export function signIn(application, username = 'ada') {
-  const userTokenData = btoa(`{"user_id":"${username}","exp":1493192602}`);
+  const userTokenData = btoa(`{"user_id":"${username}","exp":1493192602}`)
 
   authenticateSession(application, {
     data: {
@@ -15,5 +15,5 @@ export function signIn(application, username = 'ada') {
       }
     },
     jsonapi: { version: '1.0' }
-  });
+  })
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,19 +1,19 @@
-import Ember from 'ember';
-import Application from '../../app';
-import config from '../../config/environment';
+import Ember from 'ember'
+import Application from '../../app'
+import config from '../../config/environment'
 
 export default function startApp(attrs) {
   let application,
-      attributes = Ember.merge({}, config.APP);
+      attributes = Ember.merge({}, config.APP)
 
   // use defaults, but you can override;
-  attributes = Ember.merge(attributes, attrs);
+  attributes = Ember.merge(attributes, attrs)
 
   Ember.run(() => {
-    application = Application.create(attributes);
-    application.setupForTesting();
-    application.injectTestHelpers();
-  });
+    application = Application.create(attributes)
+    application.setupForTesting()
+    application.injectTestHelpers()
+  })
 
-  return application;
+  return application
 }

--- a/tests/integration/components/version-check-test.js
+++ b/tests/integration/components/version-check-test.js
@@ -1,7 +1,7 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
-import hbs from 'htmlbars-inline-precompile';
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { setupComponentTest } from 'ember-mocha'
+import hbs from 'htmlbars-inline-precompile'
 
 describe('Integration | Component | version check', () => {
   setupComponentTest('version-check', {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,4 +1,4 @@
-import resolver from './helpers/resolver';
-import { setResolver } from 'ember-mocha';
+import resolver from './helpers/resolver'
+import { setResolver } from 'ember-mocha'
 
-setResolver(resolver);
+setResolver(resolver)

--- a/tests/unit/components/version-check-test.js
+++ b/tests/unit/components/version-check-test.js
@@ -1,6 +1,6 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
-import { setupComponentTest } from 'ember-mocha';
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { setupComponentTest } from 'ember-mocha'
 
 describe('Unit | Component | version check', () => {
   setupComponentTest('version-check', {

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -1,26 +1,26 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
-import Ember from 'ember';
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { setupModelTest } from 'ember-mocha'
+import Ember from 'ember'
 
 describe('Unit | Model | organization', () => {
   setupModelTest('organization', {
     needs: ['model:repository', 'model:user']
-  });
+  })
 
   it('has many repositories', function() {
     let model = this.store().modelFor('organization'),
         relationship = Ember.get(model, 'relationshipsByName').
-                             get('repositories');
-    expect(relationship.key).to.equal('repositories');
-    expect(relationship.kind).to.equal('hasMany');
-  });
+                             get('repositories')
+    expect(relationship.key).to.equal('repositories')
+    expect(relationship.kind).to.equal('hasMany')
+  })
 
   it('has many members', function() {
     let model = this.store().modelFor('organization'),
         relationship = Ember.get(model, 'relationshipsByName').
-                             get('members');
-    expect(relationship.key).to.equal('members');
-    expect(relationship.kind).to.equal('hasMany');
-  });
-});
+                             get('members')
+    expect(relationship.key).to.equal('members')
+    expect(relationship.kind).to.equal('hasMany')
+  })
+})

--- a/tests/unit/models/repository-test.js
+++ b/tests/unit/models/repository-test.js
@@ -1,57 +1,57 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
-import Ember from 'ember';
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { setupModelTest } from 'ember-mocha'
+import Ember from 'ember'
 
 describe('Unit | Model | repository', () => {
   setupModelTest('repository', {
     needs: ['model:user', 'model:organization']
-  });
+  })
 
   it('returns the correct repository slug', function() {
-    let model = this.subject({ id: 'freddy-fazbear/some-repo' });
-    expect(model.get('repoId')).to.equal('some-repo');
-  });
+    let model = this.subject({ id: 'freddy-fazbear/some-repo' })
+    expect(model.get('repoId')).to.equal('some-repo')
+  })
 
   it('has a name', function() {
-    let model = this.subject();
-    expect(model).to.be.ok;
-  });
+    let model = this.subject()
+    expect(model).to.be.ok
+  })
 
   describe('belongs to', () => {
     it('a user', function() {
       let model = this.store().modelFor('repository'),
           relationship = Ember.get(model, 'relationshipsByName').
-        get('ownerUser');
-      expect(relationship.key).to.equal('ownerUser');
-      expect(relationship.kind).to.equal('belongsTo');
+        get('ownerUser')
+      expect(relationship.key).to.equal('ownerUser')
+      expect(relationship.kind).to.equal('belongsTo')
       Ember.run(() => {
         let user = this.store().createRecord('user', { id: 'somebody' }),
-            subject = this.subject();
-        subject.set('owner', user);
-        expect(subject.get('ownerUser.id')).to.equal(user.id);
-        expect(subject.get('ownerOrganization.id')).to.be.undefined;
-        expect(subject.get('owner.id')).to.equal(user.id);
-      });
-    });
+            subject = this.subject()
+        subject.set('owner', user)
+        expect(subject.get('ownerUser.id')).to.equal(user.id)
+        expect(subject.get('ownerOrganization.id')).to.be.undefined
+        expect(subject.get('owner.id')).to.equal(user.id)
+      })
+    })
 
     it('an organization', function() {
       let model = this.store().modelFor('repository'),
           relationship = Ember.get(model, 'relationshipsByName').
-        get('ownerOrganization');
-      expect(relationship.key).to.equal('ownerOrganization');
-      expect(relationship.kind).to.equal('belongsTo');
+        get('ownerOrganization')
+      expect(relationship.key).to.equal('ownerOrganization')
+      expect(relationship.kind).to.equal('belongsTo')
       Ember.run(() => {
         let org = this.store().createRecord(
                     'organization',
                     { id: 'some-organization' }
                   ),
-            subject = this.subject();
-        subject.set('owner', org);
-        expect(subject.get('ownerOrganization.id')).to.equal(org.id);
-        expect(subject.get('ownerUser.id')).to.be.undefined;
-        expect(subject.get('owner.id')).to.equal(org.id);
-      });
-    });
-  });
-});
+            subject = this.subject()
+        subject.set('owner', org)
+        expect(subject.get('ownerOrganization.id')).to.equal(org.id)
+        expect(subject.get('ownerUser.id')).to.be.undefined
+        expect(subject.get('owner.id')).to.equal(org.id)
+      })
+    })
+  })
+})

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,26 +1,26 @@
-import { expect } from 'chai';
-import { describe, it } from 'mocha';
-import { setupModelTest } from 'ember-mocha';
-import Ember from 'ember';
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { setupModelTest } from 'ember-mocha'
+import Ember from 'ember'
 
 describe('Unit | Model | user', () => {
   setupModelTest('user', {
     needs: ['model:repository', 'model:organization']
-  });
+  })
 
   it('has many repositories', function() {
     let model = this.store().modelFor('user'),
         relationship = Ember.get(model, 'relationshipsByName').
-                             get('repositories');
-    expect(relationship.key).to.equal('repositories');
-    expect(relationship.kind).to.equal('hasMany');
-  });
+                             get('repositories')
+    expect(relationship.key).to.equal('repositories')
+    expect(relationship.kind).to.equal('hasMany')
+  })
 
   it('has many organizations', function() {
     let model = this.store().modelFor('user'),
         relationship = Ember.get(model, 'relationshipsByName').
-                             get('organizations');
-    expect(relationship.key).to.equal('organizations');
-    expect(relationship.kind).to.equal('hasMany');
-  });
-});
+                             get('organizations')
+    expect(relationship.key).to.equal('organizations')
+    expect(relationship.kind).to.equal('hasMany')
+  })
+})


### PR DESCRIPTION
Fixes #76. The second commit also fixes the last few occurences using double quotes. It is still possible to use double quotes, if the string contains single quotes, so you don't have to escape those (see for example [here](https://github.com/ontohub/ontohub-frontend/blob/bbb4949a1f2325652363872090a74dee416d3bfa/tests/unit/components/version-check-test.js#L19)).

If there are many conflicts with issues that are currently worked on, we can defer this until those are merged, since this PR was mostly automated.