### PR TITLE
Make testem config configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 testem.log
 /app/schemas
 .vscode
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ npm-debug.log
 testem.log
 /app/schemas
 .vscode
-.env
+testem.local.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
     - "/home/travis/.yarn-cache"
 
 before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
   - "yarn --version"
   - "phantomjs --version"
   - "git clone https://github.com/ontohub/ontohub-backend ../ontohub-backend"

--- a/testem.js
+++ b/testem.js
@@ -1,29 +1,29 @@
 /* eslint-env node */
 
 let config = {
-  "framework": "mocha",
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "ignore_missing_launchers": true,
-  "parallel": 3,
-  "launch_in_ci": [
-    "PhantomJS"
+  'framework': 'mocha',
+  'test_page': 'tests/index.html?hidepassed',
+  'disable_watching': true,
+  'ignore_missing_launchers': true,
+  'parallel': 3,
+  'launch_in_ci': [
+    'PhantomJS'
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chromium",
-    "Chrome"
+  'launch_in_dev': [
+    'PhantomJS',
+    'Chromium',
+    'Chrome'
   ],
-  "browser_args": {
-    "Chromium": [
-      "--headless",
-      "--disable-gpu",
-      "--remote-debugging-port=9222"
+  'browser_args': {
+    'Chromium': [
+      '--headless',
+      '--disable-gpu',
+      '--remote-debugging-port=9222'
     ],
-    "Chrome": [
-      "--headless",
-      "--disable-gpu",
-      "--remote-debugging-port=9222"
+    'Chrome': [
+      '--headless',
+      '--disable-gpu',
+      '--remote-debugging-port=9222'
     ]
   }
 }

--- a/testem.js
+++ b/testem.js
@@ -1,40 +1,46 @@
 /* eslint-env node */
 
+/*
+ * Default testem settings. You can locally override these by creating a file
+ * `testem.local.js`. Example:
+ * ```
+ * module.exports = (defaults) => ({
+ *   launch_in_ci: defaults.launch_in_ci.concat(['Chrome', 'Safari']),
+ *   parallel: 3
+ * })
+ * ```
+ */
+
 let config = {
-  'framework': 'mocha',
-  'test_page': 'tests/index.html?hidepassed',
-  'disable_watching': true,
-  'ignore_missing_launchers': true,
-  'parallel': 3,
-  'launch_in_ci': [
-    'PhantomJS'
-  ],
-  'launch_in_dev': [
-    'PhantomJS',
-    'Chromium',
-    'Chrome'
-  ],
-  'browser_args': {
-    'Chromium': [
-      '--headless',
-      '--disable-gpu',
-      '--remote-debugging-port=9222'
-    ],
-    'Chrome': [
-      '--headless',
-      '--disable-gpu',
-      '--remote-debugging-port=9222'
-    ]
+  framework: 'mocha',
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: ['PhantomJS'],
+  launch_in_dev: ['PhantomJS', 'Chromium', 'Chrome'],
+  browser_args: {
+    Chromium: ['--headless', '--disable-gpu', '--remote-debugging-port=9222'],
+    Chrome: ['--headless', '--disable-gpu', '--remote-debugging-port=9222']
   }
 }
 
 if (process.env.TRAVIS) {
-  config.browser_args.Chromium.push('--no-sandbox')
-  config.browser_args.Chrome.push('--no-sandbox')
+  Object.assign(
+    config,
+    ((defaults) => ({
+      parallel: 2,
+      launch_in_ci: ['PhantomJS', 'Chromium'],
+      browser_args: {
+        Chromium: defaults.browser_args.Chromium.concat(['--no-sandbox'])
+      }
+    }))(config)
+  )
 }
 
-if (process.env.LAUNCHERS) {
-  config.launch_in_ci = process.env.LAUNCHERS.split(' ')
-}
+try {
+  let localConf = require('./testem.local')
 
+  Object.assign(config, localConf(config))
+} catch (e) {
+  // No local overrides
+}
 module.exports = config

--- a/testem.js
+++ b/testem.js
@@ -4,8 +4,11 @@ module.exports = {
   "framework": "mocha",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
+  "ignore_missing_launchers": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "PhantomJS",
+    "Chromium",
+    "Chrome"
   ],
   "launch_in_dev": [
     "PhantomJS",

--- a/testem.js
+++ b/testem.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 
-module.exports = {
+let config = {
   "framework": "mocha",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
@@ -28,3 +28,10 @@ module.exports = {
     ]
   }
 }
+
+if (process.env.TRAVIS) {
+  config.browser_args.Chromium.push('--no-sandbox')
+  config.browser_args.Chrome.push('--no-sandbox')
+}
+
+module.exports = config

--- a/testem.js
+++ b/testem.js
@@ -7,9 +7,7 @@ let config = {
   "ignore_missing_launchers": true,
   "parallel": 3,
   "launch_in_ci": [
-    "PhantomJS",
-    "Chromium",
-    "Chrome"
+    "PhantomJS"
   ],
   "launch_in_dev": [
     "PhantomJS",
@@ -33,6 +31,10 @@ let config = {
 if (process.env.TRAVIS) {
   config.browser_args.Chromium.push('--no-sandbox')
   config.browser_args.Chrome.push('--no-sandbox')
+}
+
+if (process.env.LAUNCHERS) {
+  config.launch_in_ci = process.env.LAUNCHERS.split(' ')
 }
 
 module.exports = config

--- a/testem.js
+++ b/testem.js
@@ -5,6 +5,7 @@ let config = {
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "ignore_missing_launchers": true,
+  "parallel": 3,
   "launch_in_ci": [
     "PhantomJS",
     "Chromium",


### PR DESCRIPTION
By default this PR changes nothing, when you are just running `ember test`. However, we can now choose which test launchers we want to run by ~~setting the `LAUNCHERS` environment variable to a space separated list of launchers (`export LAUNCHERS="Chrome Chromium"` would launch Chrome and/or Chromium, but no PhantomJS).~~ writing a local config file (see comment below).

~~Also, Launchers that were not found are ignored now (starting a test run with no launchers at all results in a successful test run, so don't do that).~~

This also configures travis to be able to run tests on Chromium ~~and Chrome as well (although only Chromium is installed). For this I set the env var `LAUNCHERS` on Travis to `"PhantomJS Chrome Chromium"`.~~

TL;DR:
- PhantomJS is now optional
- `ember test` works as normal, launching PhantomJS by default
- ~~`LAUNCHERS="Chromium Safari" ember test` launches Chromium and Safari in parallel, but not PhantomJS~~ This is configurable by a local config file.
- Travis now tests with PhantomJS and Chromium

~~Also: take a look at the `dotenv` zsh plugin if you want to specify env variables that are automatically set when entering a directory.~~