### PR TITLE
Switch to query batching

### DIFF
--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -1,4 +1,6 @@
 import { ApolloClient, createBatchingNetworkInterface } from 'react-apollo'
+import _ from 'lodash'
+import { signOut } from '../helpers/session'
 
 const backendHost = process.env.REACT_APP_BACKEND_HOST
 
@@ -42,5 +44,15 @@ networkInterface.use([
   }
 ])
 
+networkInterface.useAfter([
+  {
+    applyBatchAfterware({ responses, options }, next) {
+      if (_.some(responses, (response) => response.status === 401)) {
+        signOut(Client)
+      }
+      next()
+    }
+  }
+])
 
 export default Client

--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -1,13 +1,20 @@
-import { ApolloClient, createNetworkInterface } from 'react-apollo'
+import { ApolloClient, createBatchingNetworkInterface } from 'react-apollo'
 
 const backendHost = process.env.REACT_APP_BACKEND_HOST
 
-const networkInterface = createNetworkInterface({
-  uri: `${backendHost}/graphql`
+const networkInterface = createBatchingNetworkInterface({
+  uri: `${backendHost}/graphql`,
+  batchInterval: 10
 })
+
+export const Client = new ApolloClient({
+  networkInterface,
+  queryDeduplication: true
+})
+
 networkInterface.use([
   {
-    applyMiddleware(req, next) {
+    applyBatchMiddleware(req, next) {
       if (!req.options.headers) {
         req.options.headers = {}
       }
@@ -15,7 +22,7 @@ networkInterface.use([
     }
   },
   {
-    applyMiddleware(req, next) {
+    applyBatchMiddleware(req, next) {
       Object.assign(req.options.headers, {
         Accept: 'application/json'
       })
@@ -23,7 +30,7 @@ networkInterface.use([
     }
   },
   {
-    applyMiddleware(req, next) {
+    applyBatchMiddleware(req, next) {
       let authToken = localStorage.getItem('auth-token')
       if (authToken) {
         Object.assign(req.options.headers, {
@@ -35,8 +42,5 @@ networkInterface.use([
   }
 ])
 
-export const Client = new ApolloClient({
-  networkInterface
-})
 
 export default Client

--- a/src/containers/GlobalMenu.js
+++ b/src/containers/GlobalMenu.js
@@ -6,41 +6,19 @@ import {
 import { compose, graphql, withApollo } from 'react-apollo'
 import { GlobalMenu } from '../components'
 import { userValidations } from '../helpers/validations'
-import _ from 'lodash'
+import { signIn, signOut } from '../helpers'
 
 const enableCaptcha = process.env.REACT_APP_DISABLE_CAPTCHA !== 'true'
-
-const signOut = (client) => () => {
-  localStorage.removeItem('auth-token')
-  localStorage.removeItem('me')
-  return client.resetStore()
-}
-const signIn = (client, token, me) => {
-  if (token) {
-    localStorage.setItem('auth-token', token)
-    localStorage.setItem('me', me)
-    client.resetStore()
-  }
-}
 
 const GlobalMenuWithData = compose(
   withApollo,
   graphql(currentUserQuery, {
-    props: (props) => {
-      if (
-        !_.get(props, 'data.error.networkError') &&
-        (props.data.error || (!props.data.me && !props.data.loading))
-      ) {
-        // Invalid user token
-        signOut(props.ownProps.client)()
-      }
-      return {
-        ...props.ownProps,
-        loading: props.data.loading,
-        error: props.data.error,
-        me: props.data.me
-      }
-    }
+    props: (props) => ({
+      ...props.ownProps,
+      loading: props.data.loading,
+      error: props.data.error,
+      me: props.data.me
+    })
   }),
   graphql(signInMutation, {
     props: (props) => ({
@@ -53,16 +31,11 @@ const GlobalMenuWithData = compose(
           .then((response) => {
             const signInData = response.data.signIn
             if (signInData) {
-              return signIn(
-                props.ownProps.client,
-                signInData.jwt,
-                signInData.me
-              )
+              return signIn(props.ownProps.client, signInData.jwt)
             } else {
               throw new Error('Sign in failed')
             }
-          }),
-      onSignOut: signOut(props.ownProps.client)
+          })
     })
   }),
   graphql(signUpMutation, {
@@ -71,23 +44,20 @@ const GlobalMenuWithData = compose(
       client: undefined,
       signUpValidations: userValidations(props.ownProps.client),
       enableCaptcha: enableCaptcha,
-      onSignUp: (username, email, password, captcha) => props
-        .mutate({
-          variables: { user: { username, email, password }, captcha }
-        })
-        .then((response) => {
-          const signUpData = response.data.signUp
-          if (signUpData) {
-            return signIn(
-              props.ownProps.client,
-              signUpData.jwt,
-              signUpData.me
-            )
-          } else {
-            throw new Error('Sign up failed')
-          }
-        }),
-      onSignOut: signOut(props.ownProps.client)
+      onSignUp: (username, email, password, captcha) =>
+        props
+          .mutate({
+            variables: { user: { username, email, password }, captcha }
+          })
+          .then((response) => {
+            const signUpData = response.data.signUp
+            if (signUpData) {
+              return signIn(props.ownProps.client, signUpData.jwt)
+            } else {
+              throw new Error('Sign up failed')
+            }
+          }),
+      onSignOut: () => signOut(props.ownProps.client)
     })
   })
 )(GlobalMenu)

--- a/src/helpers/__tests__/session.test.js
+++ b/src/helpers/__tests__/session.test.js
@@ -1,0 +1,34 @@
+import { signIn, signOut } from '../session'
+
+describe('Session helpers', () => {
+  let client
+  beforeEach(() => {
+    global.localStorage = {
+      setItem: jest.fn(),
+      removeItem: jest.fn()
+    }
+    client = {
+      resetStore: jest.fn()
+    }
+  })
+
+  describe('signIn', () => {
+    it('saves the token and resets the store', () => {
+      signIn(client, 'some-token')
+      expect(client.resetStore.mock.calls.length).toBe(1)
+      expect(localStorage.setItem.mock.calls.length).toBe(1)
+    })
+    it('does nothing if no token was passed', () => {
+      signIn(client)
+      expect(client.resetStore.mock.calls.length).toBe(0)
+      expect(localStorage.setItem.mock.calls.length).toBe(0)
+    })
+  })
+  describe('signOut', () => {
+    it('removes the token and resets the store', () => {
+      signOut(client)
+      expect(client.resetStore.mock.calls.length).toBe(1)
+      expect(localStorage.removeItem.mock.calls.length).toBe(1)
+    })
+  })
+})

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,1 +1,2 @@
 export { validate, userValidations } from './validations'
+export { signIn, signOut } from './session'

--- a/src/helpers/session.js
+++ b/src/helpers/session.js
@@ -1,0 +1,11 @@
+export const signOut = (client) => {
+  localStorage.removeItem('auth-token')
+  return client.resetStore()
+}
+
+export const signIn = (client, token) => {
+  if (token) {
+    localStorage.setItem('auth-token', token)
+    client.resetStore()
+  }
+}


### PR DESCRIPTION
Uses the `batchingNetworkInterface` and should also fix #94 by moving the invalid token error handling to an afterware that that reacts to `401` errors.

Depends on ontohub/ontohub-backend#152, which will incidently push our backend version to version `0.0.0-90`, so our frontend version requirement is finally correct :tada: 