### PR TITLE
Add jest-styled-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.2.2",
     "eslint": "^4.13.1",
+    "jest-styled-components": "^4.9.0",
     "prettier": "1.9.2",
     "react-scripts": "1.0.17",
     "react-test-renderer": "^16.2.0",

--- a/src/components/__tests__/__snapshots__/GlobalMenu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/GlobalMenu.test.js.snap
@@ -1,11 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GlobalMenu signed in user matches the snapshot 1`] = `
+.c1 {
+  height: 50px;
+  width: 700px !important;
+  position: relative !important;
+}
+
+.c0 {
+  position: fixed;
+  background-color: #1B1C1D;
+  width: 100%;
+  top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 <div
-  class="sc-bwzfXH ezDetF"
+  class="c0"
 >
   <div
-    class="ui borderless inverted top fixed sc-bdVaJa cKMyHT menu"
+    class="ui borderless inverted top fixed c1 menu"
   >
     <a
       class="header item"
@@ -136,11 +157,32 @@ exports[`GlobalMenu signed in user matches the snapshot 1`] = `
 `;
 
 exports[`GlobalMenu signed out user matches the snapshot 1`] = `
+.c1 {
+  height: 50px;
+  width: 700px !important;
+  position: relative !important;
+}
+
+.c0 {
+  position: fixed;
+  background-color: #1B1C1D;
+  width: 100%;
+  top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 <div
-  class="sc-bwzfXH ezDetF"
+  class="c0"
 >
   <div
-    class="ui borderless inverted top fixed sc-bdVaJa cKMyHT menu"
+    class="ui borderless inverted top fixed c1 menu"
   >
     <a
       class="header item"

--- a/src/components/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Header.test.js.snap
@@ -1,11 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header matches the snapshot 1`] = `
+.c0 {
+  background-color: #000;
+  color: !important;
+  margin-bottom: 1em;
+}
+
+.c1 {
+  max-width: 700px;
+  margin: auto;
+}
+
+.c1 .cross-fade-leave {
+  opacity: 1;
+}
+
+.c1 .cross-fade-leave.cross-fade-leave-active {
+  opacity: 0;
+  -webkit-transition: opacity ease-in;
+  transition: opacity ease-in;
+}
+
+.c1 .cross-fade-enter {
+  opacity: 0;
+}
+
+.c1 .cross-fade-enter.cross-fade-enter-active {
+  opacity: 1;
+  -webkit-transition: opacity ease-in;
+  transition: opacity ease-in;
+}
+
+.c1 .cross-fade-height {
+  -webkit-transition: height ease-in-out;
+  transition: height ease-in-out;
+}
+
 <div
-  class="sc-bdVaJa gtWvUm"
+  class="c0"
 >
   <div
-    class="sc-bwzfXH cEnUnG"
+    class="c1"
   >
     Header content
   </div>
@@ -13,8 +49,12 @@ exports[`Header matches the snapshot 1`] = `
 `;
 
 exports[`PaddedContainer matches the snapshot 1`] = `
+.c0 {
+  padding-bottom: 1em;
+}
+
 <div
-  class="ui container sc-htpNat kTUAPG"
+  class="ui container c0"
 >
   Header content
 </div>

--- a/src/scenes/Home/__snapshots__/index.test.js.snap
+++ b/src/scenes/Home/__snapshots__/index.test.js.snap
@@ -34,8 +34,16 @@ exports[`Home Body matches the snapshot 1`] = `
 `;
 
 exports[`Home Header matches the snapshot 1`] = `
+.c1 {
+  font-weight: bold;
+}
+
+.c0 {
+  padding-bottom: 1em;
+}
+
 <div
-  class="ui container sc-EHOje bwZcKZ"
+  class="ui container c0"
 >
   <h2
     class="ui inverted header"
@@ -60,7 +68,7 @@ exports[`Home Header matches the snapshot 1`] = `
         class="content"
       >
         <span
-          class="sc-bdVaJa koclZm"
+          class="c1"
         >
           Open
         </span>
@@ -81,7 +89,7 @@ exports[`Home Header matches the snapshot 1`] = `
         class="content"
       >
         <span
-          class="sc-bdVaJa koclZm"
+          class="c1"
         >
           Flexible
         </span>
@@ -102,7 +110,7 @@ exports[`Home Header matches the snapshot 1`] = `
         class="content"
       >
         <span
-          class="sc-bdVaJa koclZm"
+          class="c1"
         >
           Distributed
         </span>

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,6 +1,7 @@
 import { configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import serializer from "enzyme-to-json/serializer";
+import "jest-styled-components";
 
 configure({ adapter: new Adapter() });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,6 +613,10 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+atob@~1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
+
 autoprefixer@7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.1.6.tgz#fb933039f74af74a83e71225ce78d9fd58ba84d7"
@@ -2467,6 +2471,15 @@ css-to-react-native@^2.0.3:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+css@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.1.tgz#73a4c81de85db664d4ee674f7d47085e3b2d55dc"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.3.0"
+    urix "^0.1.0"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -4836,6 +4849,12 @@ jest-snapshot@^20.0.3:
     natural-compare "^1.4.0"
     pretty-format "^20.0.3"
 
+jest-styled-components@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-4.9.0.tgz#459ccb37d0f5720007c8dba358bfff93c8cf4aed"
+  dependencies:
+    css "^2.2.1"
+
 jest-util@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-20.0.3.tgz#0c07f7d80d82f4e5a67c6f8b9c3fe7f65cfd32ad"
@@ -7126,6 +7145,10 @@ resolve-pathname@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
+resolve-url@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
@@ -7452,15 +7475,34 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-map-resolve@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.3.1.tgz#610f6122a445b8dd51535a2a71b783dfc1248761"
+  dependencies:
+    atob "~1.1.0"
+    resolve-url "~0.2.1"
+    source-map-url "~0.3.0"
+    urix "~0.1.0"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
     source-map "^0.5.6"
 
+source-map-url@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
+
 source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.1.38:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -8018,6 +8060,10 @@ upper-case@^1.1.1:
 urijs@^1.16.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.0.tgz#d8aa284d0e7469703a6988ad045c4cbfdf08ada0"
+
+urix@^0.1.0, urix@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
 url-loader@0.6.2, url-loader@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
This adds the `jest-styled-components` packages, which outputs styled-component's generated css alongside the components in snapshots.