### PR TITLE
Report error when no chrome is found

### DIFF
--- a/scripts/chrome
+++ b/scripts/chrome
@@ -11,3 +11,6 @@ do
   fi
 done
 
+>&2 echo "No chrome or chromium executable found in PATH"
+
+exit 1


### PR DESCRIPTION
This improves the `chrome` script to report an error and exit with an error code when no chrome executable was found in `$PATH`.